### PR TITLE
feat:検索機能(タイトル、内容、作成日)と並び替え機能を作成しました。

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -7,17 +7,19 @@ $pdo = new PDO(
     $dbPassword
 );
 
-// 検索ワードの取得
-$keyword = isset($_GET['keyword']) ? $_GET['keyword'] : '';
+$order = isset($_GET['order']) ? $_GET['order'] : 'desc'; // デフォ
+$sql = 'SELECT * FROM pages';
 
-if (!empty($keyword)) {
-  $stmt = $pdo->prepare("SELECT * FROM pages WHERE name LIKE :keyword OR contents LIKE :keyword");
-  $stmt->bindValue(':keyword', "%$keyword%", PDO::PARAM_STR);
+// ラジオボタンの選択状態に応じて
+if ($order === 'asc') {
+    $sql .= ' ORDER BY created_at ASC'; // 作成日時の昇順で並び替え
 } else {
-  $stmt = $pdo->prepare("SELECT * FROM pages");
+    $sql .= ' ORDER BY created_at DESC'; // 作成日時の降順（新着順）で並び替え（デフォ）
 }
-$stmt->execute();
-$pages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$statement = $pdo->prepare($sql);
+$statement->execute();
+$pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
 <!DOCTYPE html>
@@ -33,14 +35,6 @@ $pages = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <body>
   <div>
     <div>
-      <div>
-        <form method="GET" action="">
-          <p>絞り込み検索</p>
-          <input type="text" name="keyword" placeholder="キーワードを入力" value="<?php echo htmlspecialchars($keyword, ENT_QUOTES); ?>">
-          <button type="submit">検索</button>
-        </form>
-      </div>
-      
       <form action="index.php" method="get">
         <div>
           <label>

--- a/src/public/privatepage.php
+++ b/src/public/privatepage.php
@@ -8,13 +8,22 @@ $pdo = new PDO(
 );
 
 $sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
 
+// ラジオボタンの選択状態に応じてクエリを修正
+if (isset($_GET['order']) && $_GET['order'] === 'asc') {
+    $sql .= ' ORDER BY created_at ASC'; // 作成日時の昇順で並び替え
+} else {
+    $sql .= ' ORDER BY created_at DESC'; // 作成日時の降順（新着順）で並び替え（デフォルト）
+}
+
+$statement = $pdo->prepare($sql);
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
+
+
+
+
 
 <!DOCTYPE html>
 <html lang="ja">

--- a/src/public/privatetop.php
+++ b/src/public/privatetop.php
@@ -1,68 +1,127 @@
 <?php
-$dbUserName = 'root';
-$dbPassword = 'password';
-$pdo = new PDO(
-    'mysql:host=mysql; dbname=tq_filter; charset=utf8',
-    $dbUserName,
-    $dbPassword
-);
+session_start();
 
-$sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+try {
+    $dbUserName = 'root';
+    $dbPassword = 'password';
+    $dbName = 'tq_filter';
 
-$statement->execute();
-$pages = $statement->fetchAll(PDO::FETCH_ASSOC);
+    $pdo = new PDO("mysql:host=mysql;dbname=$dbName;charset=utf8", $dbUserName, $dbPassword);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // 初期値として新しい順に並べる
+    $orderBy = "created_at DESC";
+    $keyword = "";
+    $dateKeyword = "";
+
+    // もしGETパラメータで並び順が指定されている場合、それを適用
+    if (isset($_GET['order'])) {
+        if ($_GET['order'] === 'asc') {
+            $orderBy = "created_at ASC";
+        }
+    }
+
+    // もしGETパラメータでキーワードが指定されている場合、それを適用
+    if (isset($_GET['keyword'])) {
+        $keyword = $_GET['keyword'];
+        $keyword = "$keyword";
+    }
+
+    // もしGETパラメータで日付が指定されている場合、それを適用
+    if (isset($_GET['date_keyword'])) {
+        $dateKeyword = $_GET['date_keyword'];
+    }
+
+    // ユーザーの記事を取得するクエリを準備
+    $sql = "SELECT * FROM pages";
+
+    // クエリに条件を追加
+    $conditions = [];
+    if (!empty($keyword)) {
+        $conditions[] = "(name LIKE :keyword OR contents LIKE :keyword)";
+    }
+    if (!empty($dateKeyword)) {
+        $conditions[] = "DATE(created_at) = :date_keyword";
+    }
+
+    if (!empty($conditions)) {
+        $sql .= " WHERE " . implode(" AND ", $conditions);
+    }
+
+    $sql .= " ORDER BY $orderBy";
+
+    $stmt = $pdo->prepare($sql);
+
+    if (!empty($keyword)) {
+        $stmt->bindValue(':keyword', $keyword, PDO::PARAM_STR);
+    }
+    if (!empty($dateKeyword)) {
+        $stmt->bindValue(':date_keyword', $dateKeyword, PDO::PARAM_STR);
+    }
+
+    $stmt->execute();
+
+    // 記事のデータを取得
+    $blogs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    die("データベースへの接続に失敗しました: " . $e->getMessage());
+}
 ?>
 
 <!DOCTYPE html>
 <html lang="ja">
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>top画面</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>top画面</title>
 </head>
 
 <body>
-  <div>
+    <div>
+        <form method="GET" action="">
+            <p>絞り込み検索</p>
+            <input type="text" name="keyword" placeholder="キーワードを入力" value="<?php echo htmlspecialchars($keyword, ENT_QUOTES); ?>">
+            <input type="date" name="date_keyword" placeholder="日付を入力" value="<?php echo htmlspecialchars($dateKeyword, ENT_QUOTES); ?>">
+            <button type="submit">検索</button>
+        </form>
+    </div>
 
     <div>
-      <form action="index.php" method="get">
-        <div>
+        <form method="GET" action="">
+            <div>
+                <label>
+                    <input type="radio" name="order" value="desc" <?php if ($orderBy === 'created_at DESC') echo 'checked'; ?>>
+                    <span>新着順</span>
+                </label>
+                <label>
+                    <input type="radio" name="order" value="asc" <?php if ($orderBy === 'created_at ASC') echo 'checked'; ?>>
+                    <span>古い順</span>
+                </label>
+            </div>
+            <button type="submit">並び替え</button>
+        </form>
+    </div>
 
-          <label>
-            <input type="radio" name="order" value="desc" class="">
-            <span>新着順</span>
-          </label>
-          <label>
-            <input type="radio" name="order" value="asc" class="">
-            <span>古い順</span>
-          </label>
-        </div>
-        <button type="submit">送信</button>
-      </form>
-    </div>
-    
     <div>
-      <table border="1">
-        <tr>
-          <th>タイトル</th>
-          <th>内容</th>
-          <th>作成日時</th>
-        </tr>
-        <?php foreach ($pages as $page): ?>
-          <tr>
-            <td><?php echo $page['name']; ?></td>
-            <td><?php echo $page['contents']; ?></td>
-            <td><?php echo $page['created_at']; ?></td>
-          </tr>
-        <?php endforeach; ?>
-      </table>
+        <table border="1">
+            <tr>
+                <th>タイトル</th>
+                <th>作成日時</th>
+                <th>内容</th>
+            </tr>
+
+            <?php foreach ($blogs as $blog): ?>
+                <tr>
+                    <td><?php echo $blog['name']; ?></td>
+                    <td><?php echo $blog['created_at']; ?></td>
+                    <td><?php echo $blog['contents']; ?></td>
+                </tr>
+            <?php endforeach; ?>
+
+        </table>
     </div>
-  </div>
 </body>
 
 </html>

--- a/src/public/top.php
+++ b/src/public/top.php
@@ -6,11 +6,22 @@ $pdo = new PDO(
     $dbUserName,
     $dbPassword
 );
+//検索ワードの取得
+$keyword = isset($_GET['keyword']) ? $_GET['keyword'] : '';
 
+// クエリの基本形を定義
 $sql = 'SELECT * FROM pages';
+
+// 日付が指定された場合はクエリに日付の条件を追加
+if (!empty($keyword)) {
+  $sql .= ' WHERE DATE(created_at) = :keyword'; // 作成日の日付が一致する条件を追加
+}
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+
+if (!empty($keyword)) {
+    $statement->bindValue(':keyword', $keyword, PDO::PARAM_STR); // 日付のバインド値を設定
+}
+
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -26,6 +37,15 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 </head>
 
 <body>
+
+<div>
+    <form method="GET" action="">
+        <p>絞り込み検索</p>
+        <input type="date" name="keyword" placeholder="日付を入力" value="<?php echo htmlspecialchars($keyword, ENT_QUOTES); ?>">
+        <button type="submit">検索</button>
+    </form>
+</div>
+
   <div>
     <div>
       <form action="index.php" method="get">


### PR DESCRIPTION
## 作業対象

[作業をした教材のURL]
[https://www.notion.so/13-ff0a56bd71194fcbaa2e28f22826991c?pvs=4](url)
[作成したページのURL(privatetop.php)
(http://localhost:8080/privatetop.php)

## 作業詳細

[作成日で絞り込む機能] かつ [検索ワードでの絞り込み] かつ [作成日の新しい順、古い順に並べ替え]をする機能をprivatetop.phpに作成しました。



## 気になる点

検索ワードで絞り込んだ結果を保持したままで作成日の新しい順、古い順に並び替える　というのができませんでした。
添付動画の４２秒あたりにその様子が写っています。



https://github.com/mikan19/PHP-FilterFunction/assets/128659635/f2b87313-ccb8-4db8-a06b-c17201c46340


